### PR TITLE
Added support for the 'filter' param when available

### DIFF
--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -15,7 +15,7 @@ class Request:
         self.path = path
         self.http_method = http_method
 
-    def __call__(self, headers=None, queryParams=None, id=None, body=None, **data):
+    def __call__(self, headers=None, queryParams=None, id=None, filter=None, body=None, **data):
         method = self.http_method
         path_selected = self.url_selector(self.path, id, data)
         url = self.url_joiner(self.default_url, path_selected)
@@ -31,6 +31,9 @@ class Request:
 
         # Headers can be override
         headers = headers or self.default_headers
+
+        if filter:
+            url += "?filter=" + filter
 
         # Setting up the HTTP request
         response = self.session.request(


### PR DESCRIPTION
For example you can now type onfleet.workers.get(id=single_worker[id], filter=name,id,analytics,   queryParams={analytics: True}) that will only return the name, id, analytics, and not all the rest. That's a huge gain of performance!

There is more that can be done by including other parameters that are originally supported by the API, but that the API wrapper is unable to do, I'll see if I have time to continue my research :)

I guess the README should also be updated someday to include this possibility if the pull request is accepted.

Thanks!