### PR TITLE
more conservative error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 Visit our [blog post on the API wrapper project](https://onfleet.com/blog/api-wrappers-explained/) to learn more about our initiatives. If you have any questions, please reach out to Onfleet by submitting an issue [here](https://github.com/onfleet/pyonfleet/issues) or contact support@onfleet.com
 
-STABLE VERSION: 1.1.1
-
 ## Table of Contents
 - [Onfleet Python Wrapper](#onfleet-python-wrapper)
   * [Table of Contents](#table-of-contents)

--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -53,9 +53,12 @@ class Request:
             return response.status_code if (method == "DELETE" or "complete" in url) else response.json()
 
         error = json.loads(response.text)
-        error_code = error["message"]["error"]
-        error_message = error["message"]["message"]
-        error_request = error["message"]["request"]
+        try:
+            error_code = error["message"]["error"]
+            error_message = error["message"]["message"]
+            error_request = error["message"]["request"] 
+        except TypeError:
+            raise HttpError(error.get("message"), response.status_code, None)
         if (error_code <= 1108 and error_code >= 1100):
             raise PermissionError(error_message, error_code, error_request)
         elif (error_code == 2300):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
     name="pyonfleet",  
-    version= "1.1.1",
+    version= "1.1.2",
     author="James Li",
     author_email="support@onfleet.com",
     description="Onfleet's Python API Wrapper Package",


### PR DESCRIPTION
It's hopefully not too gauche to submit a PR for my own bug report.  This is to avoid throwing TypeError in the case the Onfleet API sends returns a response that is not the expected JSON shape.