### PR TITLE
Added error cause to HttpError class

### DIFF
--- a/onfleet/error.py
+++ b/onfleet/error.py
@@ -9,10 +9,11 @@ class PermissionError(Exception):
         self.request = request
 
 class HttpError(Exception):
-    def __init__(self, message, status, request):
+    def __init__(self, message, status, request, cause=None):
         self.message = message
         self.status = status
         self.request = request
+        self.cause = cause
 
 class RateLimitError(Exception):
     def __init__(self, message, status, request):

--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -56,7 +56,8 @@ class Request:
         try:
             error_code = error["message"]["error"]
             error_message = error["message"]["message"]
-            error_request = error["message"]["request"] 
+            error_request = error["message"]["request"]
+            error_cause = error["message"]["cause"]
         except TypeError:
             raise HttpError(error.get("message"), response.status_code, None)
         if (error_code <= 1108 and error_code >= 1100):
@@ -66,7 +67,7 @@ class Request:
         elif (error_code >= 2500):
             raise ServiceError(error_message, error_code, error_request)
         else:
-            raise HttpError(error_message, error_code, error_request)
+            raise HttpError(error_message, error_code, error_request, error_cause)
 
     @staticmethod
     def url_joiner(url, path):


### PR DESCRIPTION
This PR fix issue #19 

Was added the `error cause` into the `HttpError` class to better understand what is going wrong when an exception is raised.