### PR TITLE
pyonfleet: Expand terminology support of admin API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The base URL for the Onfleet API is `https://onfleet.com/api/v2`, here are the s
 
 | `<endpoint>` | GET | POST | PUT | DELETE |
 |:------------:|:---------------------------------------------------------------:|:----------------------------------------------------------------------:|:------------------------------------:|:-------------:|
-| [Admins](https://docs.onfleet.com/reference#administrators) | get() | create(body) | update(id, body) | deleteOne(id) |
+| [Admins/Administrators](https://docs.onfleet.com/reference#administrators) | get() | create(body) | update(id, body) | deleteOne(id) |
 | [Containers](https://docs.onfleet.com/reference#containers) | get(workers=id), get(teams=id), get(organizations=id) | x | update(id, body) | x |
 | [Destinations](https://docs.onfleet.com/reference#destinations) | get(id) | create(body) | x | x |
 | [Hubs](https://docs.onfleet.com/reference#hubs) | get() | x | x | x |

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -74,7 +74,7 @@ Onfleet應用程式介面的基本URL為 `https://onfleet.com/api/v2`，下面�
 
 | `<endpoint>` | GET | POST | PUT | DELETE |
 |:------------:|:---------------------------------------------------------------:|:----------------------------------------------------------------------:|:------------------------------------:|:-------------:|
-| [Admins](https://docs.onfleet.com/reference#administrators) | get() | create(body) | update(id, body) | deleteOne(id) |
+| [Admins/Administrators](https://docs.onfleet.com/reference#administrators) | get() | create(body) | update(id, body) | deleteOne(id) |
 | [Containers](https://docs.onfleet.com/reference#containers) | get(workers=id), get(teams=id), get(organizations=id) | x | update(id, body) | x |
 | [Destinations](https://docs.onfleet.com/reference#destinations) | get(id) | create(body) | x | x |
 | [Hubs](https://docs.onfleet.com/reference#hubs) | get() | x | x | x |

--- a/onfleet/config.py
+++ b/onfleet/config.py
@@ -6,6 +6,20 @@ class Config(object):
       auth_test = "auth/test/"
     ),
     RESOURCES = dict(
+      admins = dict(
+        GET = dict(
+          get = "/admins"
+        ),
+        POST = dict(
+          create = "/admins"
+        ),
+        PUT = dict(
+          update = "/admins/:adminId"
+        ),
+        DELETE = dict(
+          deleteOne = "/admins/:adminId"
+        )
+      ),
       administrators = dict(
         GET = dict(
           get = "/admins"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
     name="pyonfleet",  
-    version= "1.1.2",
+    version= "1.1.3",
     author="James Li",
     author_email="support@onfleet.com",
     description="Onfleet's Python API Wrapper Package",


### PR DESCRIPTION
The current wrapper uses the full `administrators` terminology to access the `admins` API endpoint, this causes some confusion with the users when they are trying to access `admins`.

The proposed change is to expand the current terminology support, and not introduce breaking changes to current integration users.