### PR TITLE
Fix issues getting error message cause when the key "cause" doesn't exists.

### DIFF
--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -57,7 +57,7 @@ class Request:
             error_code = error["message"]["error"]
             error_message = error["message"]["message"]
             error_request = error["message"]["request"]
-            error_cause = error["message"]["cause"]
+            error_cause = error["message"].get("cause")
         except TypeError:
             raise HttpError(error.get("message"), response.status_code, None)
         if (error_code <= 1108 and error_code >= 1100):


### PR DESCRIPTION
Fix issues getting error cause when the key "cause" doesn't exists.