### PR TITLE
INT-398: Announce OSS releases on Slack automatically

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -33,3 +33,32 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+  notify:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":python: A new version of `pyonfleet` has been released: `${{ github.event.release.tag_name }}`"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "See details"
+                    },
+                    "url": "${{ github.event.release.html_url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
**Describe the solution**
When creating an open-source release we want to announce it on the #internal-tools channel, automating what we currently do manually after each release.

---

**Added**

- Announce automatically a new open-source release on Slack channels