### PR TITLE
Renamed params in request.py

### DIFF
--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -27,10 +27,7 @@ class Request:
 
     @on_exception(expo, RateLimitError, max_tries=8)
     @limits(calls=RATE_LIMIT, period=1)
-    def __call__(self, id=None, body=None, queryParams=None, **extra_data):
-        obj_id = id
-        query_params = queryParams
-
+    def __call__(self, obj_id=None, body=None, query_params=None, **extra_data):
         selected_path = self._path_selector(self.path, obj_id, extra_data)
         url = f'{API_BASE_URL}{selected_path}'
 

--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -28,8 +28,8 @@ class Request:
     @on_exception(expo, RateLimitError, max_tries=8)
     @limits(calls=RATE_LIMIT, period=1)
     def __call__(self, id=None, body=None, queryParams=None, **extra_data):
-        obj_id = id  # TODO(julian): `id` is a reserved name, let's rename it to 'obj_id'
-        query_params = queryParams  # TODO(julian): Let's rename `queryParams` to `query_params`
+        obj_id = id
+        query_params = queryParams
 
         selected_path = self._path_selector(self.path, obj_id, extra_data)
         url = f'{API_BASE_URL}{selected_path}'


### PR DESCRIPTION
<!---
Loosely inspired by https://keepachangelog.com/en/1.1.0/.

Please add items to their respective section and delete empty sections.
- Added: for new features
- Changed: for changes in existing functionality
- Deprecated: for soon-to-be removed features
- Removed: for now removed features
- Fixed: for any bug fixes
- Security: in case of vulnerabilities
Ideally, each item here will be added into the upcoming release.

DO NOT post internal Onfleet links (e.g. Jira/Confluence) –this is a public space.
-->

**Describe the solution**
---
Renamed parameters `id` and `queryParams` to `obj_id` and `query_params`

**Added**
None.

**Changed**
None

**Deprecated**
None.

**Removed**
Lines 31 through 33.

**Fixed**
None.

**Security**
None.