### PR TITLE
Update request.py

### DIFF
--- a/onfleet/request.py
+++ b/onfleet/request.py
@@ -65,8 +65,8 @@ class Request:
             raise HttpError(error.get('message', 'Error'), response.status_code)
 
         error_message = error['message']['message']
-        error_code = error['message']['error']
-        error_request = error['message']['request']
+        error_code = error['message'].get('error')
+        error_request = error['message'].get('request')
         error_cause = error['message'].get('cause')
         exception_args = (error_message, error_code, error_request, error_cause)
 


### PR DESCRIPTION
**Describe the solution**

Switches from direct key access to `.get()` for optional fields (`error`, `request`, `cause`) in the Onfleet API error payload. This prevents a `KeyError` when those fields are missing and ensures the intended error (e.g., `HttpError`, `ValidationError`, etc.) is raised instead.

---

**Fixed**

Fixes #30 – prevents crashes caused by missing fields in Onfleet error responses. Now the correct exception is raised with partial error data instead of blowing up with a `KeyError`.
